### PR TITLE
when pos value is greater than int max value, bytesAvailableInCache v…

### DIFF
--- a/src/main/java/com/vivimice/bgzfrandreader/RandomAccessBgzFile.java
+++ b/src/main/java/com/vivimice/bgzfrandreader/RandomAccessBgzFile.java
@@ -279,7 +279,7 @@ public class RandomAccessBgzFile implements Closeable, AutoCloseable {
         // try read from preceding/following cache
         LocalCache[] caches = new LocalCache[] { preceding, following };
         for (LocalCache cache : caches) {
-            if (cache != null && pos >= cache.pos) {
+            if (cache != null && pos >= cache.pos && pos <= Integer.MAX_VALUE) {
                 int bytesAvailableInCache = (int) (cache.pos + cache.data.length - pos);
                 if (bytesAvailableInCache > 0) {
                     int copyLength = Math.min(bytesAvailableInCache, len);


### PR DESCRIPTION
When the pos value is greater than max value of int which is 2147483647, int bytesAvailableInCache = (int) (cache.pos + cache.data.length - pos); then bytesAvailableInCache will be calculated wrong, and that value might be greater than 0 which will enter inside the if statement causing a ArrayIndexOutOfBoundsException . Since byte array is used to hold the cache, which has an int limit, pos should be checked to see if it is less than or equal to the 2147483647 value. 