### PR TITLE
comparing (pos - cache.pos) with integer max value makes more sense than only pos being compared with integer max value. 

### DIFF
--- a/src/main/java/com/vivimice/bgzfrandreader/RandomAccessBgzFile.java
+++ b/src/main/java/com/vivimice/bgzfrandreader/RandomAccessBgzFile.java
@@ -279,7 +279,7 @@ public class RandomAccessBgzFile implements Closeable, AutoCloseable {
         // try read from preceding/following cache
         LocalCache[] caches = new LocalCache[] { preceding, following };
         for (LocalCache cache : caches) {
-            if (cache != null && pos >= cache.pos && pos <= Integer.MAX_VALUE) {
+            if (cache != null && pos >= cache.pos && (pos - cache.pos) <= Integer.MAX_VALUE) {
                 int bytesAvailableInCache = (int) (cache.pos + cache.data.length - pos);
                 if (bytesAvailableInCache > 0) {
                     int copyLength = Math.min(bytesAvailableInCache, len);


### PR DESCRIPTION
If the pos value is greater than the integer max value cache will not get used, therefore it makes more sense to compare the difference of pos - cache.pos instead of just pos being compared with integer max value. This will allow cache to be used for pos above the integer max value and also will not cause array index out of bound exception since int bytesAvailableInCache = (int) (cache.pos + cache.data.length - pos); will never be above integer max value and also System.arraycopy(cache.data, (int) (pos - cache.pos), b, off, copyLength) value will not be above integer max value. 